### PR TITLE
[DOCS/Instructions] Rewrite AI instructions in English, project-agnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,5 +15,5 @@ Full documentation for each topic lives in `docs/instructions/`. Always consult 
 | Conventional commits, versioning, releases, CI | @docs/instructions/versioning.md |
 | ADR workflow (status, PR/issue linking, rules) | @docs/instructions/adr-workflow.md |
 | ADR template (canonical structure for new ADRs) | @docs/instructions/adr-template.md |
-| GitHub sync — principe, quand & comment synchroniser | @docs/instructions/github-sync.md |
-| Templates issues & PRs — utilisation | @docs/instructions/templates.md |
+| GitHub sync — when and how to sync with GitHub | @docs/instructions/github-sync.md |
+| Issue & PR templates — usage | @docs/instructions/templates.md |

--- a/docs/instructions/adr-template.md
+++ b/docs/instructions/adr-template.md
@@ -1,7 +1,11 @@
-# ADR-XXX — Title
+# ADR Template
 
-<!-- Copy this file to docs/adr/ADR-XXX-slug.md and fill in every section. -->
+Copy this file to `docs/adr/ADR-XXX-slug.md` and fill in every section.
+Remove sections that genuinely do not apply (e.g. `## Abandonment` while the ADR is active).
 
+---
+
+```markdown
 ---
 issue: ADR-XXX
 title: …
@@ -15,52 +19,36 @@ depends_on: []          # ADRs that must be completed before this one starts
 required_by: []         # ADRs that cannot start until this one is completed
 ---
 
+# ADR-XXX — Title
+
 ## Context
 
-<!--
 Why does this decision need to be made?
 What problem are we solving, and what constraints apply?
--->
 
 ## Decisions
 
-<!--
-Bullet list of concrete technical choices made.
-Each decision should be independently understandable.
--->
-
--
+- Concrete technical choice #1
+- Concrete technical choice #2
 
 ## Alternatives considered
 
-<!--
-What other options were evaluated and why were they rejected?
--->
-
 | Option | Reason rejected |
 |--------|----------------|
-| | |
+| …      | …              |
 
 ## Goals / Commits
 
-<!--
-Checklist of the commits / sub-tasks that implement this ADR.
-Use conventional commit format: feat(<scope>): description
-Check items off as they land.
--->
-
 - [ ] `feat(<scope>): …`
+- [ ] `test(<scope>): …`
 
 ## Consequences
 
-<!--
 What does this decision make easier or harder going forward?
 Any known trade-offs or follow-up work required?
--->
 
 ## Abandonment
 
-<!--
-Only fill in if status = abandoned.
-Explain briefly why this ADR was dropped and what replaces it (if anything).
--->
+<!-- Only fill in if status = abandoned -->
+Why was this ADR dropped and what replaces it, if anything?
+```

--- a/docs/instructions/adr-workflow.md
+++ b/docs/instructions/adr-workflow.md
@@ -3,7 +3,9 @@
 Each ADR in `docs/adr/` maps to a GitHub Issue and (eventually) a PR.
 Apply these rules **every time** work touches an ADR.
 
-## Frontmatter (required on every ADR)
+## Frontmatter
+
+Every ADR file must include this YAML frontmatter:
 
 ```yaml
 ---
@@ -12,32 +14,32 @@ title: …
 branch: …               # feature branch name
 status: todo            # see lifecycle below
 pr: ~                   # GitHub PR number, or ~ if not yet opened
-pr_url: ~               # https://github.com/elydelva/mailmcp/pull/<n>
-github_issue: ~         # GitHub Issue number, or ~ if not yet created
-github_issue_url: ~     # https://github.com/elydelva/mailmcp/issues/<n>
-depends_on: []          # ADRs that must be completed before this one can start
+pr_url: ~               # full URL to the PR, or ~
+github_issue: ~         # GitHub Issue number, or ~
+github_issue_url: ~     # full URL to the issue, or ~
+depends_on: []          # ADRs that must be completed before this one starts
 required_by: []         # ADRs that cannot start until this one is completed
 ---
 ```
 
-## Dépendances entre ADRs
+## Dependencies
 
-Les champs `depends_on` et `required_by` forment un graphe orienté acyclique qui définit l'ordre d'implémentation.
+The `depends_on` / `required_by` fields form a directed acyclic graph that defines implementation order.
 
-**Règle** : un ADR ne peut passer à `in-progress` que si tous ses `depends_on` sont à `completed`.
+**Rule:** an ADR may only move to `in-progress` once all its `depends_on` entries are `completed`.
 
-Le graphe complet et l'ordre d'implémentation recommandé sont maintenus dans [`docs/adr/README.md`](../adr/README.md).
+The full graph and recommended implementation order are maintained in [`docs/adr/README.md`](../adr/README.md).
 
-Quand on écrit ou modifie un ADR :
-1. Renseigner `depends_on` avec les ADRs dont la complétion est un prérequis.
-2. Mettre à jour `required_by` sur chacun des ADRs listés dans `depends_on` (relation symétrique).
-3. Mettre à jour la table de dépendances et l'ordre dans `docs/adr/README.md`.
+When writing or modifying an ADR:
+1. Set `depends_on` to every ADR whose completion is a prerequisite.
+2. Add this ADR to `required_by` on each of those dependency ADRs (symmetric relation).
+3. Update the dependency table and implementation order in `docs/adr/README.md`.
 
-## Lifecycle — keep `status` up to date
+## Lifecycle
 
 | Status | When to set it |
-|--------|---------------|
-| `todo` | ADR written but work not started |
+|--------|----------------|
+| `todo` | ADR written, work not yet started |
 | `in-progress` | Branch created / work begun |
 | `completed` | PR merged to `main` |
 | `abandoned` | Decision dropped — add an `## Abandonment` section explaining why |
@@ -47,7 +49,7 @@ Quand on écrit ou modifie un ADR :
 1. **Starting work** — set `status: in-progress`, create the GitHub Issue if absent, fill `github_issue` + `github_issue_url`.
 2. **Opening a PR** — fill `pr` + `pr_url`, add `Closes #<github_issue>` in the PR body so GitHub auto-links it.
 3. **PR merged** — set `status: completed`.
-4. **Work dropped** — set `status: abandoned`, add `## Abandonment` section with the reason.
+4. **Work dropped** — set `status: abandoned`, add an `## Abandonment` section with the reason.
 5. **Keep `docs/adr/README.md` in sync** — the status column must always match the frontmatter.
 6. Never leave `pr`, `pr_url`, `github_issue`, or `github_issue_url` blank — use `~` (YAML null) when unknown.
 

--- a/docs/instructions/github-sync.md
+++ b/docs/instructions/github-sync.md
@@ -1,60 +1,60 @@
-# GitHub Sync — Principe & Workflow
+# GitHub Sync
 
-## Source de vérité : le dépôt git
+## Git is the source of truth
 
-À l'ère de l'IA, **le dépôt git est la seule source de vérité fiable** :
+In an AI-assisted workflow, **the git repository is the only reliable source of truth**:
 
-- Les commits, branches et tags sont immuables et vérifiables.
-- Les ADRs (`docs/adr/`) documentent les décisions architecturales de façon durable.
-- Les messages de commit (Conventional Commits) constituent le changelog vivant.
+- Commits, branches, and tags are immutable and auditable.
+- ADRs (`docs/adr/`) record architectural decisions durably.
+- Commit messages (Conventional Commits) form the living changelog.
 
-GitHub Issues et PRs sont une **couche UX** par-dessus git. Ils peuvent être supprimés, archivés, ou devenir obsolètes. Ne jamais leur faire confiance pour du contexte critique — ce contexte doit vivre dans les commits ou les ADRs.
+GitHub Issues and PRs are a **UX layer** on top of git. They can be deleted, archived, or become stale. Never rely on them for critical context — that context belongs in commits or ADRs.
 
-## Pourquoi on sync quand même
+## Why sync at all
 
-GitHub offre une interface de collaboration précieuse : revue de code, discussion, signalement de WIP via les Draft PRs, lien visuel entre issues et PRs. On en profite, sans en dépendre.
+GitHub provides valuable collaboration tooling: code review, discussion threads, WIP signaling via Draft PRs, and visual traceability between issues and PRs. We use it, without depending on it.
 
-## Quand synchroniser
+## When to sync
 
-| Moment | Action GitHub |
-|--------|--------------|
-| Démarrage du travail sur un ADR | Ouvrir l'issue correspondante si elle n'existe pas encore |
-| Début du développement actif | Ouvrir une **Draft PR** depuis la branche, liée à l'issue (`Closes #N`) |
-| Prêt pour review | Marquer la Draft PR comme **Ready for review** |
-| PR mergée | L'issue se ferme automatiquement via `Closes #N` |
-| Travail abandonné | Fermer l'issue manuellement avec un commentaire bref, mettre `status: abandoned` dans l'ADR |
+| Moment | GitHub action |
+|--------|---------------|
+| Starting work on an ADR | Open the corresponding issue if it does not exist |
+| First significant commit on the branch | Open a **Draft PR** linked to the issue (`Closes #N`) |
+| Ready for review | Mark the Draft PR as **Ready for review** |
+| PR merged | Issue closes automatically via `Closes #N` |
+| Work dropped | Close the issue manually with a brief comment; set `status: abandoned` in the ADR |
 
-## Draft PR — signal de WIP
+## Draft PRs as WIP signals
 
-Ouvrir une Draft PR **dès que la branche a un premier commit significatif**, même si le travail n'est pas terminé. C'est un signal :
-- pour les collaborateurs (humains ou IA) que ce travail est en cours,
-- pour garder la traçabilité entre branche et issue visible dans l'interface GitHub.
+Open a Draft PR **as soon as the branch has a first meaningful commit**, even if work is unfinished. It signals:
+- to collaborators (human or AI) that this work is in progress,
+- traceability between the branch and the issue is visible in the GitHub UI.
 
-Une Draft PR ne déclenche pas de review requests. La convertir en PR normale quand le travail est prêt.
+Draft PRs do not trigger review requests. Convert to a regular PR when the work is ready.
 
-## Nommage des PRs
+## PR title format
 
-Le titre d'une PR **n'est pas** un message de commit. Il doit être lisible par un humain qui parcourt la liste des PRs, pas par un parser de changelog.
+A PR title is **not** a commit message. It must be readable by a human scanning the PR list, not parsed by a changelog tool.
 
-Format : `[TYPE/Nom de la feature]` suivi d'une courte phrase en langage naturel.
+Format: `[TYPE/Feature Name]` followed by a short human-readable sentence.
 
 ```
-[FEAT/Storage]    Implémentation du backend fichier avec chiffrement AES-256
-[FIX/IMAP]        Correction du timeout de connexion sur les serveurs lents
-[DOCS/ADR]        Workflow ADR, templates et hub d'instructions IA
-[CHORE/CI]        Découplage SonarCloud et publication GHCR
+[FEAT/Auth]       Add OAuth 2.1 PKCE flow
+[FIX/IMAP]        Handle connection timeout on slow servers
+[DOCS/ADR]        ADR workflow, templates, and AI instruction hub
+[CHORE/CI]        Decouple SonarCloud scanning and GHCR publishing
 ```
 
-Types disponibles : `FEAT`, `FIX`, `DOCS`, `CHORE`, `REFACTOR`, `PERF`, `TEST`
+Available types: `FEAT`, `FIX`, `DOCS`, `CHORE`, `REFACTOR`, `PERF`, `TEST`
 
-> Les Conventional Commits restent dans les messages de commit — ils alimentent le changelog automatique.
-> Le titre de PR, lui, sert la lisibilité humaine dans l'interface GitHub.
+> Conventional Commits belong in individual commit messages — they feed the automated changelog.
+> PR titles serve human readability in the GitHub interface.
 
-## Comment synchroniser (règles concrètes)
+## Sync checklist
 
-1. **Nommer la PR** selon le format `[TYPE/Nom]` décrit ci-dessus — jamais comme un commit.
-2. **Toujours lier** une PR à son issue avec `Closes #<N>` dans le corps de la PR.
-3. **Toujours renseigner** `pr`, `pr_url`, `github_issue`, `github_issue_url` dans le frontmatter de l'ADR correspondant (voir [`adr-workflow.md`](./adr-workflow.md)).
-4. **Utiliser les templates** de `docs/templates/` pour ouvrir issues et PRs (voir [`templates.md`](./templates.md)).
-5. **Ne pas dupliquer le contexte** : le corps d'une issue ou PR peut résumer, mais la décision technique durable doit être dans l'ADR ou le commit.
-6. **Ne pas bloquer sur GitHub** : si l'interface est inaccessible, le travail continue — git suffit. La sync se fait a posteriori.
+1. **Name the PR** using the `[TYPE/Name]` format above — never like a commit message.
+2. **Always link** a PR to its issue with `Closes #<N>` in the PR body.
+3. **Always fill** `pr`, `pr_url`, `github_issue`, `github_issue_url` in the corresponding ADR frontmatter (see [`adr-workflow.md`](./adr-workflow.md)).
+4. **Use the templates** in `docs/templates/` when opening issues or PRs (see [`templates.md`](./templates.md)).
+5. **Do not duplicate context** — a PR or issue body may summarize, but durable technical decisions live in the ADR or commit.
+6. **Never block on GitHub** — if the interface is unavailable, work continues; sync can happen after the fact.

--- a/docs/instructions/templates.md
+++ b/docs/instructions/templates.md
@@ -1,48 +1,47 @@
-# Templates — Utilisation
+# Templates
 
-Les templates pour issues et PRs sont dans `docs/templates/`.
+Issue and PR templates live in `docs/templates/`.
 
 ```
 docs/templates/
   issues/
-    bug.md       ← signalement d'un bug
-    feature.md   ← demande de fonctionnalité / nouveau ADR
+    bug.md       ← unexpected behavior / regression
+    feature.md   ← new work linked to an ADR or feature
   pr/
-    bugfix.md    ← PR corrigeant un bug
-    feature.md   ← PR implémentant un ADR / feature
+    bugfix.md    ← PR fixing a bug
+    feature.md   ← PR implementing an ADR or feature
 ```
 
-## Quand utiliser quel template
+## Which template to use
 
 | Situation | Template |
 |-----------|---------|
-| Comportement inattendu / régresssion | `issues/bug.md` |
-| Nouveau travail lié à un ADR ou feature | `issues/feature.md` |
-| PR corrigeant un bug (issue de type bug) | `pr/bugfix.md` |
-| PR implémentant un ADR ou feature | `pr/feature.md` |
+| Unexpected behavior or regression | `issues/bug.md` |
+| New work linked to an ADR or feature | `issues/feature.md` |
+| PR fixing a bug | `pr/bugfix.md` |
+| PR implementing an ADR or feature | `pr/feature.md` |
 
-## Comment créer une issue avec le template
+## Creating an issue from a template
 
 ```sh
-# Copier le template, l'éditer, puis créer l'issue
 gh issue create --title "ADR-00X — …" --body-file docs/templates/issues/feature.md
 ```
 
-## Comment créer une PR avec le template
+## Creating a PR from a template
 
-Le titre suit le format `[TYPE/Nom de la feature]` — voir [`github-sync.md`](./github-sync.md#nommage-des-prs).
+PR titles follow the `[TYPE/Feature Name]` format — see [`github-sync.md`](./github-sync.md#pr-title-format).
 
 ```sh
-# Draft PR dès le premier commit significatif
+# Open a Draft PR as soon as the branch has a first meaningful commit
 gh pr create --draft \
-  --title "[FEAT/Storage] Implémentation du backend fichier avec chiffrement AES-256" \
+  --title "[FEAT/Auth] Add OAuth 2.1 PKCE flow" \
   --body-file docs/templates/pr/feature.md \
   --base main
 
-# Convertir en PR normale quand prête
+# Promote to ready when the work is complete
 gh pr ready <number>
 ```
 
-## Règle générale
+## General rule
 
-Les templates sont des points de départ — adapter le contenu au contexte réel. Ne pas laisser de sections vides avec leur placeholder : soit les remplir, soit les supprimer.
+Templates are starting points — adapt the content to the actual context. Remove any section that does not apply rather than leaving empty placeholders.

--- a/docs/instructions/versioning.md
+++ b/docs/instructions/versioning.md
@@ -2,7 +2,9 @@
 
 Versioning is fully automated via **Conventional Commits** + **release-please**.
 
-## Commit format (enforced by Husky + commitlint)
+## Commit format
+
+Enforced by Husky + commitlint on every commit:
 
 ```
 <type>(<scope>): <description>
@@ -18,23 +20,29 @@ Versioning is fully automated via **Conventional Commits** + **release-please**.
 | `refactor`, `test`, `ci`, `chore` | — | hidden |
 | `feat!` / `BREAKING CHANGE:` | **major** | yes |
 
+**Rules:**
+- Subject must be lower-case (enforced by commitlint `subject-case`).
+- Use the imperative mood: "add", "fix", "remove" — not "added", "fixes".
+- Scope is the package or module name: `(imap)`, `(auth)`, `(server)`, `(core)`.
+
 Examples:
 ```
 feat(auth): add OAuth 2.1 PKCE flow
 fix(imap): handle connection timeout gracefully
 feat!: drop Node.js support — Bun only
+chore(ci): add release-please workflow
 ```
 
 ## Release pipeline
 
 1. Each merge to `main` triggers the `release-please` workflow.
-2. release-please maintains a **"Release PR"** that bumps `package.json` and updates `CHANGELOG.md`.
-3. Merging the Release PR creates the GitHub Release and Git tag.
-4. The tag triggers the Docker publish job in `release-please.yml`.
+2. release-please maintains a **Release PR** that bumps `package.json` and updates `CHANGELOG.md`.
+3. Merging the Release PR creates the GitHub Release and the git tag.
+4. The tag triggers the Docker publish job.
 
 ## CI Docker images
 
 | Event | Image tag |
 |-------|-----------|
-| Push to `main` | `ghcr.io/<org>/mailmcp:main`, `:sha-<sha>` |
+| Push to `main` | `ghcr.io/<org>/<repo>:main`, `:<sha>` |
 | Release tag | `:1.2.3`, `:1.2`, `:1`, `:latest` |

--- a/docs/templates/issues/bug.md
+++ b/docs/templates/issues/bug.md
@@ -1,33 +1,33 @@
-## Comportement observé
+## Observed behavior
 
-<!-- Décris ce qui se passe actuellement. -->
+<!-- What is currently happening? -->
 
-## Comportement attendu
+## Expected behavior
 
-<!-- Décris ce qui devrait se passer. -->
+<!-- What should happen instead? -->
 
-## Étapes pour reproduire
+## Steps to reproduce
 
 1.
 2.
 3.
 
-## Environnement
+## Environment
 
-- OS :
-- Version / commit :
-- Commande exécutée :
+- OS:
+- Version / commit:
+- Command executed:
 
 ## Logs / stack trace
 
 ```
-<!-- Coller ici les logs ou l'erreur. -->
+<!-- Paste logs or error output here. -->
 ```
 
 ## Impact
 
-<!-- Bloquant / majeur / mineur ? Qui est affecté ? -->
+<!-- Blocking / major / minor? Who is affected? -->
 
-## Contexte additionnel
+## Additional context
 
-<!-- Tout ce qui peut aider : PR liée, ADR concerné, screenshot, etc. -->
+<!-- Anything that may help: related PR, ADR reference, screenshot, etc. -->

--- a/docs/templates/issues/feature.md
+++ b/docs/templates/issues/feature.md
@@ -1,27 +1,25 @@
-## Contexte
+## Context
 
-<!-- Quel besoin ou décision technique motive cette issue ?
-     Si elle correspond à un ADR, mentionner le numéro (ex: ADR-003). -->
+<!-- What need or technical decision motivates this issue?
+     If it maps to an ADR, reference the number (e.g. ADR-003). -->
 
-## Objectif
+## Goal
 
-<!-- Ce que cette issue doit accomplir, en une ou deux phrases. -->
+<!-- What should this issue accomplish, in one or two sentences? -->
 
-## Tâches
-
-<!-- Checklist des sous-tâches à compléter. -->
+## Tasks
 
 - [ ]
 - [ ]
 
-## ADR associé
+## Related ADR
 
-<!-- Lien vers le fichier ADR correspondant, ou "aucun" si hors-ADR. -->
+<!-- Link to the corresponding ADR file, or "none" if this is not ADR-driven. -->
 
 [ADR-XXX](../../adr/ADR-XXX-slug.md)
 
-## Critères d'acceptation
+## Acceptance criteria
 
-<!-- Comment saura-t-on que c'est terminé ? Tests, comportement observable, etc. -->
+<!-- How will we know this is done? Tests, observable behavior, etc. -->
 
 - [ ]

--- a/docs/templates/pr/bugfix.md
+++ b/docs/templates/pr/bugfix.md
@@ -1,36 +1,36 @@
-## Résumé
+## Summary
 
-<!-- Une ou deux phrases décrivant le bug corrigé et l'approche. -->
+<!-- One or two sentences describing the bug fixed and the approach taken. -->
 
-Closes #<!-- numéro de l'issue bug -->
+Closes #<!-- bug issue number -->
 
-## Cause racine
+## Root cause
 
-<!-- Explication concise de la cause du bug. -->
+<!-- Concise explanation of what caused the bug. -->
 
-## Correction apportée
+## Fix
 
-<!-- Ce qui a été changé et pourquoi c'est la bonne approche. -->
+<!-- What was changed and why this is the right approach. -->
 
-## Reproduction avant / après
+## Before / after
 
-<!-- Optionnel mais utile : commande ou scénario montrant le bug disparu. -->
+<!-- Optional but helpful: command or scenario showing the bug is gone. -->
 
-**Avant :**
+**Before:**
 ```
 ```
 
-**Après :**
+**After:**
 ```
 ```
 
 ## Checklist
 
-- [ ] Les tests passent (`bun test`)
-- [ ] Un test de non-régression a été ajouté (ou justification de son absence)
-- [ ] Le type check passe (`bun run typecheck`)
-- [ ] Le lint passe (`bun run lint`)
+- [ ] Tests pass
+- [ ] Regression test added (or reason it is not needed)
+- [ ] Type check passes
+- [ ] Lint passes
 
-## Notes de review
+## Review notes
 
-<!-- Effets de bord potentiels, cas limites, etc. -->
+<!-- Potential side effects, edge cases, anything worth flagging. -->

--- a/docs/templates/pr/feature.md
+++ b/docs/templates/pr/feature.md
@@ -1,30 +1,30 @@
-## Résumé
+## Summary
 
-<!-- Une ou deux phrases décrivant ce que cette PR accomplit. -->
+<!-- One or two sentences describing what this PR accomplishes. -->
 
-Closes #<!-- numéro de l'issue -->
+Closes #<!-- issue number -->
 
-## ADR associé
+## Related ADR
 
-<!-- Lien vers le fichier ADR implémenté par cette PR. -->
+<!-- Link to the ADR implemented by this PR. -->
 
 [ADR-XXX](../../adr/ADR-XXX-slug.md)
 
-## Changements notables
+## Notable changes
 
-<!-- Bullet points des changements techniques importants.
-     Ne pas paraphraser les commits — mentionner ce qui est non-évident. -->
+<!-- Bullet points of non-obvious technical changes.
+     Do not paraphrase the commits — highlight what is surprising or worth reviewing. -->
 
 -
 
 ## Checklist
 
-- [ ] Les tests passent (`bun test`)
-- [ ] Le type check passe (`bun run typecheck`)
-- [ ] Le lint passe (`bun run lint`)
-- [ ] Le frontmatter de l'ADR est mis à jour (`pr`, `pr_url`, `status`)
-- [ ] `docs/adr/README.md` est à jour
+- [ ] Tests pass
+- [ ] Type check passes
+- [ ] Lint passes
+- [ ] ADR frontmatter updated (`pr`, `pr_url`, `status`)
+- [ ] `docs/adr/README.md` status column updated
 
-## Notes de review
+## Review notes
 
-<!-- Points d'attention particuliers pour le reviewer, compromis acceptés, etc. -->
+<!-- Particular attention points, accepted trade-offs, known limitations. -->


### PR DESCRIPTION
## Summary

Rewrites all `docs/instructions/` and `docs/templates/` files to be professional, in English, and project-agnostic — usable as-is on any project.

## Notable changes

- All French prose translated to English
- Project-specific references (`elydelva/mailmcp`, French examples) replaced with generic placeholders
- `versioning.md`: added explicit commitlint rules section; Docker image tags use `<org>/<repo>`
- `github-sync.md`: PR title examples in English
- `adr-template.md`: restructured as a clean copy-paste template with inline comments
- All issue and PR templates (`docs/templates/**`) translated to English

## Checklist

- [ ] Tests pass
- [ ] Type check passes
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)