### PR TITLE
[FEAT/Batch] Add batch email operations with filter support and batch_archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,62 @@ mailmcp workspace add work https://mail.work.example.com
 
 ## What Claude can do with your email
 
-| Ask Claude to… | Tool used |
+### Account management
+
+| Tool | What it does |
 |---|---|
-| "Show my unread emails" | `list_emails` |
-| "Read the thread with Alice" | `get_thread` |
-| "Search for invoices from last month" | `search_emails` |
-| "Reply to Bob's message" | `reply_email` |
-| "Send a draft to the team" | `send_email` |
-| "Move all newsletters to Archives" | `batch_move` |
-| "Delete emails older than 6 months" | `batch_delete` |
-| "Mark everything from GitHub as read" | `batch_mark` |
+| `setup_account` | Add a new email account (provider auto-detected) |
+| `list_accounts` | List all configured accounts |
+| `set_default_account` | Change the default account |
+| `delete_account` | Remove an account |
+
+### Reading & searching
+
+| Tool | What it does |
+|---|---|
+| `list_emails` | List emails with pagination (`page`, `limit`) |
+| `get_email` | Fetch a single email by UID (full body + attachments) |
+| `get_thread` | Fetch an entire conversation thread by UID |
+| `list_folders` | List all mailbox folders |
+| `search_emails` | Search emails by keyword |
+
+### Sending
+
+| Tool | What it does |
+|---|---|
+| `send_email` | Compose and send a new email |
+| `reply_email` | Reply to an existing email (preserves threading headers) |
+| `forward_email` | Forward an email to new recipients |
+
+### Single-email actions
+
+| Tool | What it does |
+|---|---|
+| `move_email` | Move an email to another folder |
+| `delete_email` | Permanently delete an email |
+| `mark_email` | Mark as read / unread / flagged / unflagged |
+
+### Batch actions (up to 500 emails per call)
+
+Accepts either an explicit list of UIDs or a server-side filter (`from`, `subject`, `before`, `after`, `read`).
+
+| Tool | What it does |
+|---|---|
+| `batch_move` | Move multiple emails to a folder |
+| `batch_delete` | Permanently delete multiple emails |
+| `batch_mark` | Mark multiple emails as read / unread / flagged |
+| `batch_archive` | Move multiple emails to the Archive folder (auto-detected) |
+
+**Examples:**
+```
+"Show my unread emails"                       → list_emails
+"Read the thread with Alice"                  → get_thread
+"Search for invoices from last month"         → search_emails
+"Reply to Bob's message"                      → reply_email
+"Archive all newsletters from this week"      → batch_archive (filter: from + after)
+"Delete emails older than 6 months"           → batch_delete (filter: before)
+"Mark everything from GitHub as read"         → batch_mark   (filter: from)
+```
 
 ---
 

--- a/docs/adr/ADR-016-batch-operations.md
+++ b/docs/adr/ADR-016-batch-operations.md
@@ -1,0 +1,59 @@
+---
+issue: ADR-016
+title: MCP Tools — Batch Email Operations
+branch: feat/batch-operations
+status: in-progress
+pr: ~
+pr_url: ~
+github_issue: ~
+github_issue_url: ~
+depends_on: [ADR-008, ADR-015]
+required_by: []
+---
+
+# ADR-016 — MCP Tools: Batch Email Operations
+
+## Context
+
+Les outils MCP actuels (ADR-008) permettent des actions sur un email à la fois (`delete_email`, `move_email`, `mark_email`). Pour des cas d'usage courants — vider une boîte, archiver une campagne, marquer 100 emails comme lus — cela génère N appels successifs, ce qui est lent et coûteux en tokens.
+
+Ce ADR ajoute des outils MCP dédiés aux opérations en lot, capables de traiter jusqu'à plusieurs centaines d'emails en un seul appel.
+
+## Decisions
+
+- Nouveaux outils exposés via MCP :
+  - `batch_delete` — supprime une liste d'UIDs ou tous les emails correspondant à un filtre
+  - `batch_move` — déplace une liste d'UIDs vers un dossier cible
+  - `batch_mark` — marque une liste d'UIDs (`read`, `unread`, `flagged`, `unflagged`)
+  - `batch_archive` — raccourci pour `batch_move` vers le dossier Archive détecté automatiquement
+- Entrée acceptée sous deux formes :
+  - `uids: string[]` — liste explicite d'UIDs IMAP
+  - `filter: { folder?, from?, subject?, before?, after?, read? }` — résolution côté serveur avant exécution
+- Limite configurable : maximum 500 UIDs par appel (rejeté avec une erreur claire si dépassé)
+- Implémentation en `packages/core/tools/batch.ts`, même convention handler que ADR-007/008
+- Utilisation des commandes IMAP `UID STORE` et `UID COPY` + `UID STORE \Deleted` + `EXPUNGE` en lot pour minimiser les round-trips
+
+## Alternatives considered
+
+| Option | Reason rejected |
+|--------|----------------|
+| Réutiliser `batch_delete` existant de ADR-008 | Déjà présent en stub mais sans support `filter` ni limite de sécurité |
+| Exposer un outil générique `batch_action` | Trop ouvert — signature difficile à valider et à documenter pour un LLM |
+| Implémenter côté client (appels répétés) | N round-trips réseau, pas atomique, expérience agent dégradée |
+
+## Goals / Commits
+
+- [ ] `feat(core): add batch_delete handler with uid list and filter support`
+- [ ] `feat(core): add batch_move handler with uid list and filter support`
+- [ ] `feat(core): add batch_mark handler with uid list and filter support`
+- [ ] `feat(core): add batch_archive shortcut handler`
+- [ ] `feat(server): register batch tools in fastify-mcp`
+- [ ] `test(core): unit tests for batch handlers`
+- [ ] `docs: update tool reference with batch tools`
+
+## Consequences
+
+- Les agents LLM peuvent accomplir des tâches de gestion de boîte entière en un seul appel outil.
+- La limite à 500 UIDs protège contre les opérations accidentellement destructrices sur de très grandes boîtes.
+- Le support du `filter` introduit une résolution IMAP `SEARCH` côté serveur avant exécution — ajoute une latence légère mais réduit la charge token.
+- Les opérations batch IMAP ne sont pas atomiques sur tous les serveurs ; un échec partiel sera reporté dans la réponse avec les UIDs ayant échoué.

--- a/docs/adr/ADR-016-batch-operations.md
+++ b/docs/adr/ADR-016-batch-operations.md
@@ -3,10 +3,10 @@ issue: ADR-016
 title: MCP Tools — Batch Email Operations
 branch: feat/batch-operations
 status: in-progress
-pr: ~
-pr_url: ~
-github_issue: ~
-github_issue_url: ~
+pr: 61
+pr_url: https://github.com/elydelva/mailmcp/pull/61
+github_issue: 60
+github_issue_url: https://github.com/elydelva/mailmcp/issues/60
 depends_on: [ADR-008, ADR-015]
 required_by: []
 ---

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ Each ADR maps to a GitHub Issue, a git branch, and describes the goals and progr
 | [ADR-013](ADR-013-typescript-project-references.md) | TypeScript project references — monorepo typecheck scalability | — | completed |
 | [ADR-014](ADR-014-core-package-split.md) | Split @mailmcp/core by responsibility + rename CLI | `core` + `mailmcp` | completed |
 | [ADR-015](ADR-015-email-body-rendering.md) | Email body rendering pipeline — MIME, extraction, Markdown | `parser` | completed |
+| [ADR-016](ADR-016-batch-operations.md) | MCP Tools — Batch Email Operations | `core` + `server` | in-progress |
 
 ---
 
@@ -67,6 +68,7 @@ ADR-001 ──┼──► ADR-010 ──┬──► ADR-002 ──┐
 | ADR-013 | ADR-012 | — |
 | ADR-014 | ADR-010, ADR-013 | — |
 | ADR-015 | ADR-008, ADR-014 | — |
+| ADR-016 | ADR-008, ADR-015 | — |
 
 ---
 
@@ -91,4 +93,6 @@ Les ADRs sur la même ligne peuvent être travaillés en parallèle.
         │ ADR-009  (Docker — nécessite ADR-003, ADR-010)
          │
 Étape 6 │ ADR-015  (Email body rendering — nécessite ADR-008, ADR-014)
+         │
+Étape 7 │ ADR-016  (Batch email operations — nécessite ADR-008, ADR-015)
 ```

--- a/packages/imap/src/index.ts
+++ b/packages/imap/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./client.js";
+export type { BatchFilter } from "./operations.js";
 export * from "./operations.js";
 export * from "./pool.js";

--- a/packages/imap/src/operations.ts
+++ b/packages/imap/src/operations.ts
@@ -250,6 +250,107 @@ export async function deleteEmail(client: ImapFlow, uid: number, mailbox: string
   await client.messageDelete(`${uid}`, { uid: true });
 }
 
+// ---------------------------------------------------------------------------
+// Batch helpers
+// ---------------------------------------------------------------------------
+
+/** Structured filter for resolving a set of UIDs via IMAP SEARCH. */
+export interface BatchFilter {
+  from?: string;
+  subject?: string;
+  /** Upper bound — messages older than this date */
+  before?: Date;
+  /** Lower bound — messages newer than this date */
+  after?: Date;
+  read?: boolean;
+}
+
+/** Resolve a BatchFilter to a list of UIDs using IMAP SEARCH. */
+export async function searchByFilter(
+  client: ImapFlow,
+  mailbox: string,
+  filter: BatchFilter,
+): Promise<number[]> {
+  await client.mailboxOpen(mailbox);
+  const criteria: Record<string, unknown> = {};
+  if (filter.from) criteria.from = filter.from;
+  if (filter.subject) criteria.subject = filter.subject;
+  if (filter.before) criteria.before = filter.before;
+  if (filter.after) criteria.since = filter.after;
+  if (filter.read !== undefined) criteria.seen = filter.read;
+  const uids = await client.search(criteria, { uid: true });
+  return Array.isArray(uids) ? uids : [];
+}
+
+/** Build a UID sequence-set string from an array of UIDs (e.g. "1,2,3"). */
+function uidSet(uids: number[]): string {
+  return uids.join(",");
+}
+
+/**
+ * Move multiple messages to another mailbox in a single IMAP command.
+ */
+export async function batchMoveEmails(
+  client: ImapFlow,
+  uids: number[],
+  from: string,
+  to: string,
+): Promise<void> {
+  if (uids.length === 0) return;
+  await client.mailboxOpen(from);
+  await client.messageMove(uidSet(uids), to, { uid: true });
+}
+
+/**
+ * Permanently delete multiple messages in a single IMAP command.
+ */
+export async function batchDeleteEmails(
+  client: ImapFlow,
+  uids: number[],
+  mailbox: string,
+): Promise<void> {
+  if (uids.length === 0) return;
+  await client.mailboxOpen(mailbox);
+  await client.messageDelete(uidSet(uids), { uid: true });
+}
+
+/**
+ * Set read / flagged status on multiple messages in a single IMAP command.
+ */
+export async function batchMarkEmails(
+  client: ImapFlow,
+  uids: number[],
+  mailbox: string,
+  flags: { read?: boolean; flagged?: boolean },
+): Promise<void> {
+  if (uids.length === 0) return;
+  await client.mailboxOpen(mailbox);
+  const set = uidSet(uids);
+  const opts = { uid: true };
+
+  if (flags.read !== undefined) {
+    if (flags.read) await client.messageFlagsAdd(set, ["\\Seen"], opts);
+    else await client.messageFlagsRemove(set, ["\\Seen"], opts);
+  }
+
+  if (flags.flagged !== undefined) {
+    if (flags.flagged) await client.messageFlagsAdd(set, ["\\Flagged"], opts);
+    else await client.messageFlagsRemove(set, ["\\Flagged"], opts);
+  }
+}
+
+/**
+ * Find the Archive folder name by looking for the \Archive special-use flag,
+ * then falling back to common name patterns.
+ */
+export async function findArchiveFolder(client: ImapFlow): Promise<string | null> {
+  const folders = await client.list();
+  const byFlag = folders.find((f) => f.flags?.has("\\Archive"));
+  if (byFlag) return byFlag.path;
+  const byName = folders.find((f) => /^(archive|archived|\[gmail\]\/all mail)$/i.test(f.path));
+  return byName?.path ?? null;
+}
+
 /**
  * Set read / flagged status on a message by UID.
  */

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -1,5 +1,6 @@
 import type { ToolContext } from "@mailmcp/tools";
 import {
+  batchArchive,
   batchDelete,
   batchMark,
   batchMove,
@@ -330,13 +331,25 @@ export function registerEmailTools(server: McpServer, ctx: ToolContext): void {
     },
   );
 
+  const batchFilterSchema = z
+    .object({
+      from: z.string().optional(),
+      subject: z.string().optional(),
+      before: z.coerce.date().optional(),
+      after: z.coerce.date().optional(),
+      read: z.boolean().optional(),
+    })
+    .optional();
+
   server.registerTool(
     "batch_move",
     {
-      description: "Move multiple emails to another mailbox",
+      description:
+        "Move multiple emails to another mailbox. Provide either explicit uids or a filter to resolve them server-side (max 500).",
       inputSchema: z.object({
         accountId: z.string().optional(),
-        uids: z.array(z.number().int().positive()),
+        uids: z.array(z.number().int().positive()).optional(),
+        filter: batchFilterSchema,
         mailbox: z.string(),
         destination: z.string(),
       }),
@@ -354,10 +367,12 @@ export function registerEmailTools(server: McpServer, ctx: ToolContext): void {
   server.registerTool(
     "batch_delete",
     {
-      description: "Permanently delete multiple emails",
+      description:
+        "Permanently delete multiple emails. Provide either explicit uids or a filter to resolve them server-side (max 500).",
       inputSchema: z.object({
         accountId: z.string().optional(),
-        uids: z.array(z.number().int().positive()),
+        uids: z.array(z.number().int().positive()).optional(),
+        filter: batchFilterSchema,
         mailbox: z.string(),
       }),
       annotations: { destructiveHint: true },
@@ -374,10 +389,12 @@ export function registerEmailTools(server: McpServer, ctx: ToolContext): void {
   server.registerTool(
     "batch_mark",
     {
-      description: "Mark multiple emails as read/unread or flagged/unflagged",
+      description:
+        "Mark multiple emails as read/unread or flagged/unflagged. Provide either explicit uids or a filter (max 500).",
       inputSchema: z.object({
         accountId: z.string().optional(),
-        uids: z.array(z.number().int().positive()),
+        uids: z.array(z.number().int().positive()).optional(),
+        filter: batchFilterSchema,
         mailbox: z.string(),
         read: z.boolean().optional(),
         flagged: z.boolean().optional(),
@@ -387,6 +404,28 @@ export function registerEmailTools(server: McpServer, ctx: ToolContext): void {
     async (params) => {
       try {
         return ok(await batchMark(ctx, params));
+      } catch (e) {
+        return err(e);
+      }
+    },
+  );
+
+  server.registerTool(
+    "batch_archive",
+    {
+      description:
+        "Archive multiple emails (move to the Archive folder). Provide either explicit uids or a filter (max 500).",
+      inputSchema: z.object({
+        accountId: z.string().optional(),
+        uids: z.array(z.number().int().positive()).optional(),
+        filter: batchFilterSchema,
+        mailbox: z.string(),
+      }),
+      annotations: { destructiveHint: true },
+    },
+    async (params) => {
+      try {
+        return ok(await batchArchive(ctx, params));
       } catch (e) {
         return err(e);
       }

--- a/packages/tools/src/emails.test.ts
+++ b/packages/tools/src/emails.test.ts
@@ -192,25 +192,27 @@ function createMockPool(
     search: async (_q: unknown) => {
       return (overrides.searchEmails ?? []).map((e) => e.uid);
     },
-    messageMove: async (_uid: string, to: string) => {
-      moves.push({ uid: Number(_uid), from: "", to });
+    messageMove: async (uidSet: string, to: string) => {
+      for (const uid of uidSet.split(",")) moves.push({ uid: Number(uid), from: "", to });
     },
-    messageDelete: async (_uid: string) => {
-      deletes.push({ uid: Number(_uid), mailbox: "" });
+    messageDelete: async (uidSet: string) => {
+      for (const uid of uidSet.split(",")) deletes.push({ uid: Number(uid), mailbox: "" });
     },
-    messageFlagsAdd: async (_uid: string, flags: string[]) => {
-      marks.push({
-        uid: Number(_uid),
-        mailbox: "",
-        flags: { read: flags.includes("\\Seen"), flagged: flags.includes("\\Flagged") },
-      });
+    messageFlagsAdd: async (uidSet: string, flags: string[]) => {
+      for (const uid of uidSet.split(","))
+        marks.push({
+          uid: Number(uid),
+          mailbox: "",
+          flags: { read: flags.includes("\\Seen"), flagged: flags.includes("\\Flagged") },
+        });
     },
-    messageFlagsRemove: async (_uid: string, flags: string[]) => {
-      marks.push({
-        uid: Number(_uid),
-        mailbox: "",
-        flags: { read: !flags.includes("\\Seen"), flagged: !flags.includes("\\Flagged") },
-      });
+    messageFlagsRemove: async (uidSet: string, flags: string[]) => {
+      for (const uid of uidSet.split(","))
+        marks.push({
+          uid: Number(uid),
+          mailbox: "",
+          flags: { read: !flags.includes("\\Seen"), flagged: !flags.includes("\\Flagged") },
+        });
     },
   };
 

--- a/packages/tools/src/emails.test.ts
+++ b/packages/tools/src/emails.test.ts
@@ -4,6 +4,7 @@ import type { CreateAccountInput, EmailAccount, StorageAdapter, User } from "@ma
 import { encrypt } from "@mailmcp/storage";
 import type { ToolContext } from "./context.js";
 import {
+  batchArchive,
   batchDelete,
   batchMark,
   batchMove,
@@ -129,6 +130,7 @@ function createMockPool(
     getEmail?: EmailMessage | null;
     listFolders?: MailboxInfo[];
     searchEmails?: EmailSummary[];
+    archiveFolder?: string;
     moveEmail?: () => void;
     deleteEmail?: () => void;
     markEmail?: () => void;
@@ -148,12 +150,21 @@ function createMockPool(
 
   const fakeClient = {
     usable: true,
-    list: async () =>
-      (overrides.listFolders ?? []).map((f) => ({
+    list: async () => {
+      const folders = (overrides.listFolders ?? []).map((f) => ({
         path: f.name,
         delimiter: f.delimiter,
         flags: new Set(f.flags),
-      })),
+      }));
+      if (overrides.archiveFolder) {
+        folders.push({
+          path: overrides.archiveFolder,
+          delimiter: "/",
+          flags: new Set(["\\Archive"]),
+        });
+      }
+      return folders;
+    },
     mailboxOpen: async () => {},
     fetch: async function* (range: unknown, _q: unknown) {
       // When range is an array of UIDs (from search), use searchEmails data;
@@ -435,6 +446,147 @@ describe("batchMark", () => {
     expect(result.status).toBe("ok");
     expect(result.marked).toBe(3);
     expect(mockPool._marks).toHaveLength(3);
+  });
+});
+
+describe("batchMove with filter", () => {
+  test("resolves uids via IMAP SEARCH when filter is provided", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const mockPool = createMockPool({ searchEmails: [makeEmail(10), makeEmail(20)] });
+    const result = await batchMove(
+      ctx,
+      { filter: { from: "newsletter@example.com" }, mailbox: "INBOX", destination: "Newsletters" },
+      { pool: mockPool },
+    );
+    expect(result.status).toBe("ok");
+    expect(result.moved).toBe(2);
+    expect(mockPool._moves).toHaveLength(2);
+    expect(mockPool._moves.map((m) => m.uid)).toEqual([10, 20]);
+  });
+});
+
+describe("batchDelete with filter", () => {
+  test("resolves uids via filter and deletes them", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const mockPool = createMockPool({ searchEmails: [makeEmail(5), makeEmail(6), makeEmail(7)] });
+    const result = await batchDelete(
+      ctx,
+      { filter: { subject: "promo" }, mailbox: "INBOX" },
+      { pool: mockPool },
+    );
+    expect(result.status).toBe("ok");
+    expect(result.deleted).toBe(3);
+    expect(mockPool._deletes).toHaveLength(3);
+  });
+});
+
+describe("batchMark with filter", () => {
+  test("marks emails matching a filter as read", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const mockPool = createMockPool({ searchEmails: [makeEmail(1), makeEmail(2)] });
+    const result = await batchMark(
+      ctx,
+      { filter: { read: false }, mailbox: "INBOX", read: true },
+      { pool: mockPool },
+    );
+    expect(result.status).toBe("ok");
+    expect(result.marked).toBe(2);
+  });
+});
+
+describe("batch uid limit", () => {
+  test("throws when more than 500 uids are provided", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const uids = Array.from({ length: 501 }, (_, i) => i + 1);
+    const mockPool = createMockPool();
+    await expect(batchDelete(ctx, { uids, mailbox: "INBOX" }, { pool: mockPool })).rejects.toThrow(
+      "Batch limit exceeded",
+    );
+  });
+
+  test("accepts exactly 500 uids", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const uids = Array.from({ length: 500 }, (_, i) => i + 1);
+    const mockPool = createMockPool();
+    const result = await batchDelete(ctx, { uids, mailbox: "INBOX" }, { pool: mockPool });
+    expect(result.status).toBe("ok");
+    expect(result.deleted).toBe(500);
+  });
+});
+
+describe("batch missing input", () => {
+  test("throws when neither uids nor filter are provided", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const mockPool = createMockPool();
+    await expect(batchDelete(ctx, { mailbox: "INBOX" }, { pool: mockPool })).rejects.toThrow(
+      "Either uids or filter must be provided",
+    );
+  });
+});
+
+describe("batchArchive", () => {
+  test("moves emails to the detected archive folder", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const mockPool = createMockPool({ archiveFolder: "Archive" });
+    const result = await batchArchive(
+      ctx,
+      { uids: [1, 2, 3], mailbox: "INBOX" },
+      { pool: mockPool },
+    );
+    expect(result.status).toBe("ok");
+    expect(result.archived).toBe(3);
+    expect(result.destination).toBe("Archive");
+    expect(mockPool._moves.every((m) => m.to === "Archive")).toBe(true);
+  });
+
+  test("resolves uids via filter before archiving", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const mockPool = createMockPool({
+      archiveFolder: "Archive",
+      searchEmails: [makeEmail(10), makeEmail(11)],
+    });
+    const result = await batchArchive(
+      ctx,
+      { filter: { from: "newsletter@example.com" }, mailbox: "INBOX" },
+      { pool: mockPool },
+    );
+    expect(result.status).toBe("ok");
+    expect(result.archived).toBe(2);
+  });
+
+  test("throws when no archive folder exists", async () => {
+    const storage = createMemoryStorage();
+    await createAccountInStorage(storage, "user-1");
+    const ctx: ToolContext = { userId: "user-1", storage };
+
+    const mockPool = createMockPool();
+    await expect(
+      batchArchive(ctx, { uids: [1], mailbox: "INBOX" }, { pool: mockPool }),
+    ).rejects.toThrow("No Archive folder found");
   });
 });
 

--- a/packages/tools/src/emails.ts
+++ b/packages/tools/src/emails.ts
@@ -1,5 +1,9 @@
-import type { ImapPool } from "@mailmcp/imap";
+import type { BatchFilter, ImapPool } from "@mailmcp/imap";
 import {
+  findArchiveFolder,
+  batchDeleteEmails as imapBatchDelete,
+  batchMarkEmails as imapBatchMark,
+  batchMoveEmails as imapBatchMove,
   deleteEmail as imapDeleteEmail,
   getEmail as imapGetEmail,
   listEmails as imapListEmails,
@@ -8,6 +12,7 @@ import {
   moveEmail as imapMoveEmail,
   imapPool,
   searchEmails as imapSearchEmails,
+  searchByFilter,
 } from "@mailmcp/imap";
 import { renderEmail } from "@mailmcp/parser";
 import type { AttachmentInput } from "@mailmcp/smtp";
@@ -125,23 +130,35 @@ export interface MarkEmailParams {
 
 export interface BatchMoveParams {
   accountId?: string;
-  uids: number[];
+  /** Explicit list of UIDs. Required if `filter` is not provided. */
+  uids?: number[];
+  /** Resolve UIDs via IMAP SEARCH. Required if `uids` is not provided. */
+  filter?: BatchFilter;
   mailbox: string;
   destination: string;
 }
 
 export interface BatchDeleteParams {
   accountId?: string;
-  uids: number[];
+  uids?: number[];
+  filter?: BatchFilter;
   mailbox: string;
 }
 
 export interface BatchMarkParams {
   accountId?: string;
-  uids: number[];
+  uids?: number[];
+  filter?: BatchFilter;
   mailbox: string;
   read?: boolean;
   flagged?: boolean;
+}
+
+export interface BatchArchiveParams {
+  accountId?: string;
+  uids?: number[];
+  filter?: BatchFilter;
+  mailbox: string;
 }
 
 // ── Read tools ────────────────────────────────────────────────────────────────
@@ -299,14 +316,28 @@ export async function markEmail(ctx: ToolContext, params: MarkEmailParams, _deps
 
 // ── Batch tools ───────────────────────────────────────────────────────────────
 
+const BATCH_LIMIT = 500;
+
+async function resolveBatchUids(
+  client: Parameters<typeof searchByFilter>[0],
+  mailbox: string,
+  uids: number[] | undefined,
+  filter: BatchFilter | undefined,
+): Promise<number[]> {
+  if (uids !== undefined) return uids;
+  if (filter !== undefined) return searchByFilter(client, mailbox, filter);
+  throw new Error("Either uids or filter must be provided");
+}
+
 export async function batchMove(ctx: ToolContext, params: BatchMoveParams, _deps: EmailDeps = {}) {
-  const { accountId, uids, mailbox, destination } = params;
+  const { accountId, uids: rawUids, filter, mailbox, destination } = params;
   const { account, password } = await resolveAccount(ctx, accountId);
   const pool = _deps.pool ?? ctx.imapPool ?? imapPool;
   const client = await pool.getClient(ctx.userId, account, password);
-  for (const uid of uids) {
-    await imapMoveEmail(client, uid, mailbox, destination);
-  }
+  const uids = await resolveBatchUids(client, mailbox, rawUids, filter);
+  if (uids.length > BATCH_LIMIT)
+    throw new Error(`Batch limit exceeded: ${uids.length} UIDs (max ${BATCH_LIMIT})`);
+  await imapBatchMove(client, uids, mailbox, destination);
   return { status: "ok" as const, moved: uids.length };
 }
 
@@ -315,23 +346,43 @@ export async function batchDelete(
   params: BatchDeleteParams,
   _deps: EmailDeps = {},
 ) {
-  const { accountId, uids, mailbox } = params;
+  const { accountId, uids: rawUids, filter, mailbox } = params;
   const { account, password } = await resolveAccount(ctx, accountId);
   const pool = _deps.pool ?? ctx.imapPool ?? imapPool;
   const client = await pool.getClient(ctx.userId, account, password);
-  for (const uid of uids) {
-    await imapDeleteEmail(client, uid, mailbox);
-  }
+  const uids = await resolveBatchUids(client, mailbox, rawUids, filter);
+  if (uids.length > BATCH_LIMIT)
+    throw new Error(`Batch limit exceeded: ${uids.length} UIDs (max ${BATCH_LIMIT})`);
+  await imapBatchDelete(client, uids, mailbox);
   return { status: "ok" as const, deleted: uids.length };
 }
 
 export async function batchMark(ctx: ToolContext, params: BatchMarkParams, _deps: EmailDeps = {}) {
-  const { accountId, uids, mailbox, read, flagged } = params;
+  const { accountId, uids: rawUids, filter, mailbox, read, flagged } = params;
   const { account, password } = await resolveAccount(ctx, accountId);
   const pool = _deps.pool ?? ctx.imapPool ?? imapPool;
   const client = await pool.getClient(ctx.userId, account, password);
-  for (const uid of uids) {
-    await imapMarkEmail(client, uid, mailbox, { read, flagged });
-  }
+  const uids = await resolveBatchUids(client, mailbox, rawUids, filter);
+  if (uids.length > BATCH_LIMIT)
+    throw new Error(`Batch limit exceeded: ${uids.length} UIDs (max ${BATCH_LIMIT})`);
+  await imapBatchMark(client, uids, mailbox, { read, flagged });
   return { status: "ok" as const, marked: uids.length };
+}
+
+export async function batchArchive(
+  ctx: ToolContext,
+  params: BatchArchiveParams,
+  _deps: EmailDeps = {},
+) {
+  const { accountId, uids: rawUids, filter, mailbox } = params;
+  const { account, password } = await resolveAccount(ctx, accountId);
+  const pool = _deps.pool ?? ctx.imapPool ?? imapPool;
+  const client = await pool.getClient(ctx.userId, account, password);
+  const archive = await findArchiveFolder(client);
+  if (!archive) throw new Error("No Archive folder found on this account");
+  const uids = await resolveBatchUids(client, mailbox, rawUids, filter);
+  if (uids.length > BATCH_LIMIT)
+    throw new Error(`Batch limit exceeded: ${uids.length} UIDs (max ${BATCH_LIMIT})`);
+  await imapBatchMove(client, uids, mailbox, archive);
+  return { status: "ok" as const, archived: uids.length, destination: archive };
 }


### PR DESCRIPTION
## Summary

Implements ADR-016: adds MCP tools for batch email operations (delete, move, mark, archive) capable of processing up to 500 emails in a single call, with optional server-side filter resolution via IMAP SEARCH.

Closes #60

## Related ADR

[ADR-016](docs/adr/ADR-016-batch-operations.md)

## Notable changes

- **Single IMAP round-trip per batch**: handlers now pass a UID sequence set string (e.g. `"1,2,3"`) to `messageMove`/`messageDelete`/`messageFlagsAdd` instead of N sequential calls — significant latency reduction for large batches.
- **Filter-based resolution**: callers can pass a `filter` object (`from`, `subject`, `before`, `after`, `read`) instead of explicit UIDs; the server resolves matching UIDs via IMAP SEARCH before executing the operation.
- **`batch_archive`**: new tool that auto-detects the Archive folder via `\Archive` special-use flag (with fallback to name patterns) then moves in one command.
- **500-uid hard limit**: enforced at handler level with a clear error message; protects against accidental large-scale destructive operations.

## Checklist

- [x] Tests pass (162/162)
- [x] Type check passes
- [x] Lint passes
- [ ] ADR frontmatter updated (`pr`, `pr_url`, `status`)
- [x] `docs/adr/README.md` status column updated

## Review notes

- IMAP batch commands are not atomic on all servers (RFC 3501 does not guarantee partial rollback). A failure on a batch command will fail the entire operation — no partial success tracking.
- `batch_archive` throws if no Archive folder is detected; callers should use `list_folders` first if unsure.